### PR TITLE
# Correct one of the sort options from sort by Date to sort by id

### DIFF
--- a/public/App.js
+++ b/public/App.js
@@ -74,7 +74,7 @@ class App extends React.Component{
                 <ul>
                     <li onClick={() => {this.handleSort("Size")}}>Size</li>
                     <li onClick={() => {this.handleSort("Price")}}>Price</li>
-                    <li onClick={() => {this.handleSort("Date")}}>Date</li>
+                    <li onClick={() => {this.handleSort("Id")}}>Id</li>
                 </ul>
                 </div>
             </div>


### PR DESCRIPTION
#### What does this PR do?
This PR corrects one of the sort options from `sort by Date` to `sort by id`
#### How can it be tested?
- Clone this repo `git clone https://github.com/johnkegz/creatella-react-test.git`
- cd into the `creatella-react-test` directory.
- Run `npm start` to start the application
- Click on the sort button on top
- One of the sort options will be by `id` not Date
#### Any background context
- N/A

